### PR TITLE
Scroll the download pane into view when a version is selected and make some consistency changes to navbar

### DIFF
--- a/src/lib/components/nav/Navbar.svelte
+++ b/src/lib/components/nav/Navbar.svelte
@@ -233,7 +233,7 @@
       </div>
       {#if $authed}
         <Tooltip
-          tooltipText="{'Create project'}"
+          tooltipText="{'Create Project'}"
           placement="{'bottom'}"
           classes="flex">
           <a
@@ -271,7 +271,12 @@
           {/if}
         {/if}
       {/if}
-      <ColorSchemeSelector />
+      <Tooltip
+        tooltipText="{'Switch Theme'}"
+        placement="{'bottom'}"
+        classes="flex">
+        <ColorSchemeSelector />
+      </Tooltip>
       {#if $authed}
         <a
           on:mouseenter="{() => (showUserPanel = true)}"

--- a/src/routes/project/[project]/download/+page.svelte
+++ b/src/routes/project/[project]/download/+page.svelte
@@ -15,6 +15,7 @@
   import IconAlert from "~icons/tabler/AlertHexagon.svelte";
   import IconFiles from "~icons/tabler/Files.svelte";
   import autoAnimate from "@formkit/auto-animate";
+  import { tick } from "svelte";
 
   export let data: PageData;
 
@@ -39,6 +40,9 @@
     }
     if (matches?.length == 0)
       return toast.info("The latest version doesn't support " + vs);
+    tick().then(() => {
+      document.querySelector("#download-content")?.scrollIntoView();
+    });
   }
 </script>
 
@@ -120,7 +124,8 @@
         </div>
         {#if matches.length > 0}
           <div
-            class="rounded-xl bg-slate-200 p-3 dark:bg-zinc-800"
+            id="download-content"
+            class="scroll-mt-20 rounded-xl bg-slate-200 p-3 dark:bg-zinc-800"
             use:autoAnimate>
             <p class="MB-6 text-white">
               Latest version for {pickedVersion}:


### PR DESCRIPTION
Compatibility:
CSS `scroll-margin`: https://caniuse.com/?search=scroll-margin
JS `DOMElement.scrollIntoView(..)`: https://caniuse.com/?search=scrollintoview

One thing I noticed is that tailwind `scroll-mt-20` wasn't really doing much, not sure if it's just me (it was doing something, just not enough, not sure if I was using it wrong 🤷‍♂️)

I was checking out the mobile download page and noticed that when you press one of the versions there's no indicator that it has actually opened, so I made it scroll into view.