### PR TITLE
use misode/mcmeta versions & send data_pack_version/pack_format to backend

### DIFF
--- a/src/lib/components/project/ProjectComponent.svelte
+++ b/src/lib/components/project/ProjectComponent.svelte
@@ -7,6 +7,7 @@
   import IconNoPhoto from "~icons/tabler/Polaroid.svelte";
   import IconUpdate from "~icons/tabler/Refresh.svelte";
   import Tooltip from "../utility/Tooltip.svelte";
+  import { dpvDictAll } from "$lib/globals/versions";
 
   export let project: Project;
   export let showStatus = false;
@@ -70,7 +71,7 @@
             .sort()}
           <span>•</span>
           <span>
-            {mcVersions.at(-1)}
+            {dpvDictAll[mcVersions[mcVersions.length - 1]] ?? mcVersions[mcVersions.length - 1]}
           </span>
         {:else}
           <span>•</span>

--- a/src/lib/components/project/VersionDisplay.svelte
+++ b/src/lib/components/project/VersionDisplay.svelte
@@ -150,7 +150,7 @@
                   mcv,
                   version.resource_pack_download !== undefined
                 )}">
-              {dpvDictAll[mcv]}
+              {dpvDictAll[mcv] ?? mcv}
             </button>
           </li>
         {/each}
@@ -223,7 +223,7 @@
             mcv,
             version?.resource_pack_download ? true : false
           );
-        }}">{dpvDictAll[mcv]}</Button>
+        }}">{dpvDictAll[mcv] ?? mcv}</Button>
     {/each}
   </div>
   <p class="pr-1 text-xs italic text-zinc-950 dark:text-white">

--- a/src/lib/components/project/VersionDisplay.svelte
+++ b/src/lib/components/project/VersionDisplay.svelte
@@ -185,7 +185,7 @@
       ><IconZIP />
       <span data-test-clickable-label="datapack">Datapack</span>
       {#if mcVersion}
-        <span>(for {mcVersion})</span>{/if}</Button>
+        <span>(for {dpvDictAll[mcVersion]})</span>{/if}</Button>
     {#if version.resource_pack_download}
       <Button
         click="{() => {

--- a/src/lib/components/project/VersionDisplay.svelte
+++ b/src/lib/components/project/VersionDisplay.svelte
@@ -139,11 +139,11 @@
     </div>
     {#if !mcVersion}
       <ul
-        class="hidden gap-1 text-zinc-950 md:flex md:flex-grow dark:text-white">
+        class="hidden gap-1 text-zinc-950 md:flex md:flex-wrap dark:text-white">
         {#each properVersion as mcv}
           <li>
             <button
-              class="rounded-md bg-dph-orange p-1 px-2 text-xs"
+              class="rounded-md bg-dph-orange p-1 px-2 text-xs truncate"
               on:click="{() =>
                 download(
                   version.primary_download,

--- a/src/lib/components/project/VersionDisplay.svelte
+++ b/src/lib/components/project/VersionDisplay.svelte
@@ -6,7 +6,6 @@
   import MarkdownComponent from "../markdown/MarkdownRenderer.svelte";
   import Modal from "../modals/Modal.svelte";
 
-  import { dpPackFormats } from "$lib/globals/consts";
   import { fetchAuthed } from "$lib/globals/functions";
   import type { Project, Version } from "$lib/globals/schema";
   import { user } from "$lib/globals/stores";
@@ -18,6 +17,7 @@
   import IconRP from "~icons/tabler/Sparkles.svelte";
   import Button from "../decorative/Button.svelte";
   import Tooltip from "../utility/Tooltip.svelte";
+  import { dpvDictAll } from "$lib/globals/versions";
 
   export let version: Version;
   export let expanded = false;
@@ -44,7 +44,7 @@
 
   async function download(
     url: string | undefined,
-    mcSemver: string,
+    version: string,
     rp: boolean
   ) {
     if (!browser || url === undefined) {
@@ -75,9 +75,7 @@
     }
 
     let mcMeta = JSON.parse(await parsedZip.files["pack.mcmeta"].async("text"));
-    let packFormat = 0;
-
-    packFormat = dpPackFormats.find(v => mcSemver === v.label)?.format || 0;
+    let packFormat = parseInt(version);
 
     mcMeta.pack.pack_format = packFormat;
 
@@ -152,7 +150,7 @@
                   mcv,
                   version.resource_pack_download !== undefined
                 )}">
-              {mcv}
+              {dpvDictAll[mcv]}
             </button>
           </li>
         {/each}
@@ -225,7 +223,7 @@
             mcv,
             version?.resource_pack_download ? true : false
           );
-        }}">{mcv}</Button>
+        }}">{dpvDictAll[mcv]}</Button>
     {/each}
   </div>
   <p class="pr-1 text-xs italic text-zinc-950 dark:text-white">

--- a/src/lib/globals/consts.ts
+++ b/src/lib/globals/consts.ts
@@ -32,35 +32,6 @@ export const roleNames = [
   "default"
 ];
 
-/** All Minecraft Versions */
-export const minecraftVersions = [
-  "1.13",
-  "1.15",
-  "1.16.2",
-  "1.17.x",
-  "1.18",
-  "1.18.2",
-  "1.19",
-  "1.19.4",
-  "1.20",
-  "1.20.2",
-  "1.20.3"
-];
-
-export const dpPackFormats = [
-  { format: 4, label: "1.13" },
-  { format: 5, label: "1.15" },
-  { format: 6, label: "1.16.2" },
-  { format: 7, label: "1.17" },
-  { format: 8, label: "1.18" },
-  { format: 9, label: "1.18.2" },
-  { format: 10, label: "1.19" },
-  { format: 12, label: "1.19.4" },
-  { format: 15, label: "1.20" },
-  { format: 18, label: "1.20.2" },
-  { format: 26, label: "1.20.3" }
-];
-
 export type FeaturedProjectTypes =
   | "random"
   | "featured"

--- a/src/lib/globals/versions.ts
+++ b/src/lib/globals/versions.ts
@@ -17,8 +17,8 @@ type MinecraftVersion = {
 const response = await fetch("https://raw.githubusercontent.com/misode/mcmeta/summary/versions/data.min.json");
 const minecraftVersionData: MinecraftVersion[] = await response.json();
 
-const dpvDict: {[dataPackVersion: number]: string} = {};
-const dpvDictSnapshot: {[dataPackVersion: number]: string} = {};
+const dpvDict: {[dataPackVersion: string]: string} = {};
+const dpvDictAll: {[dataPackVersion: string]: string} = {};
 
 let lastStable: string = "newest";
 for (let i = minecraftVersionData[0].data_pack_version; i > 0; i--) {
@@ -29,25 +29,26 @@ for (let i = minecraftVersionData[0].data_pack_version; i > 0; i--) {
     const stableMcVs: MinecraftVersion[] = mcVs.filter((version: MinecraftVersion) => version.stable);
     if (stableMcVs.length === 1) {
         dpvDict[i] = stableMcVs[0].id;
+        dpvDictAll[i] = stableMcVs[0].id;
         lastStable = stableMcVs[0].id;
     } else if (stableMcVs.length > 1) {
         dpvDict[i] = `${stableMcVs[stableMcVs.length-1].id} - ${stableMcVs[0].id}`;
+        dpvDictAll[i] = `${stableMcVs[stableMcVs.length-1].id} - ${stableMcVs[0].id}`;
         lastStable = stableMcVs[0].id;
-    }
-    if (mcVs.length === 1) {
-        dpvDictSnapshot[i] = mcVs[0].id + " (" + lastStable + ")";
+    } else if (mcVs.length === 1) {
+        dpvDictAll[i] = mcVs[0].id + " (" + lastStable + ")";
     } else if (mcVs.length > 1) {
-        dpvDictSnapshot[i] = `${mcVs[mcVs.length-1].id} - ${mcVs[0].id} (${lastStable})`;
+        dpvDictAll[i] = `${mcVs[mcVs.length-1].id} - ${mcVs[0].id} (${lastStable})`;
     }
 }
 
 export const getDataPackVersion = (version: string): string => {
-    for (const dpv in dpvDictSnapshot) {
-        if (dpvDict[dpv] === version || dpvDictSnapshot[dpv] === version) {
+    for (const dpv in dpvDictAll) {
+        if (dpvDict[dpv] === version || dpvDictAll[dpv] === version) {
             return dpv;
         }
     }
     throw new Error(`Unknown version ${version}`);
 };
 
-export { dpvDict, dpvDictSnapshot };
+export { dpvDict, dpvDictAll };

--- a/src/lib/globals/versions.ts
+++ b/src/lib/globals/versions.ts
@@ -1,0 +1,44 @@
+
+type MinecraftVersion = {
+    id: string;
+    name: string;
+    release_target: null | string;
+    type: string;
+    stable: boolean;
+    data_version: number;
+    protocol_version: number;
+    data_pack_version: number;
+    resource_pack_version: number;
+    build_time: string;
+    release_time: string;
+    sha1: string;
+};
+
+const response = await fetch("https://raw.githubusercontent.com/misode/mcmeta/summary/versions/data.min.json");
+const minecraftVersionData: MinecraftVersion[] = await response.json();
+
+const dpvDict: {[dataPackVersion: number]: string} = {};
+const dpvDictSnapshot: {[dataPackVersion: number]: string} = {};
+
+let lastStable: string = "newest";
+for (let i = minecraftVersionData[0].data_pack_version; i > 0; i--) {
+    const mcVs: MinecraftVersion[] = minecraftVersionData.filter((version: MinecraftVersion) => version.data_pack_version === i);
+    if (mcVs.length === 0) {
+        continue;
+    }
+    const stableMcVs: MinecraftVersion[] = mcVs.filter((version: MinecraftVersion) => version.stable);
+    if (stableMcVs.length === 1) {
+        dpvDict[i] = stableMcVs[0].id;
+        lastStable = stableMcVs[0].id;
+    } else if (stableMcVs.length > 1) {
+        dpvDict[i] = `${stableMcVs[stableMcVs.length-1].id} - ${stableMcVs[0].id}`;
+        lastStable = stableMcVs[0].id;
+    }
+    if (mcVs.length === 1) {
+        dpvDictSnapshot[i] = mcVs[0].id + " (" + lastStable + ")";
+    } else if (mcVs.length > 1) {
+        dpvDictSnapshot[i] = `${mcVs[mcVs.length-1].id} - ${mcVs[0].id} (${lastStable})`;
+    }
+}
+
+export { dpvDict, dpvDictSnapshot };

--- a/src/lib/globals/versions.ts
+++ b/src/lib/globals/versions.ts
@@ -51,4 +51,14 @@ export const getDataPackVersion = (version: string): string => {
     throw new Error(`Unknown version ${version}`);
 };
 
+export const versionMatches = (version: string, versions: string): boolean => { // this is only nessecary to make old versions work
+    const versionsArray = versions.split(",").map(s => s.trim());
+    if (version === "26") {
+        return versionsArray.includes("1.20.3") || versionsArray.includes("1.20.4") || versionsArray.includes("26");
+    } else if (version === "18") {
+        return versionsArray.includes("1.20.2") || versionsArray.includes("18");
+    }
+    return versionsArray.includes(version) || versionsArray.find(s => s.substring(0, 4) === dpvDictAll[version].substring(0, 4)) !== undefined;
+};
+
 export { dpvDict, dpvDictAll };

--- a/src/lib/globals/versions.ts
+++ b/src/lib/globals/versions.ts
@@ -41,4 +41,13 @@ for (let i = minecraftVersionData[0].data_pack_version; i > 0; i--) {
     }
 }
 
+export const getDataPackVersion = (version: string): string => {
+    for (const dpv in dpvDictSnapshot) {
+        if (dpvDict[dpv] === version || dpvDictSnapshot[dpv] === version) {
+            return dpv;
+        }
+    }
+    throw new Error(`Unknown version ${version}`);
+};
+
 export { dpvDict, dpvDictSnapshot };

--- a/src/routes/project/[project]/download/+page.svelte
+++ b/src/routes/project/[project]/download/+page.svelte
@@ -15,7 +15,7 @@
   import IconFiles from "~icons/tabler/Files.svelte";
   import autoAnimate from "@formkit/auto-animate";
   import { tick } from "svelte";
-  import { dpvDictAll } from "$lib/globals/versions";
+  import { dpvDictAll, versionMatches } from "$lib/globals/versions";
 
   export let data: PageData;
 
@@ -33,13 +33,11 @@
   function pickVersions(vs: string) {
     matches = [];
     pickedVersion = vs;
-    for (const v of data.versions.filter((versions: Version) =>
-      versions.minecraft_versions.split(",").includes(vs)
-    )) {
+    for (const v of data.versions.filter((versions: Version) => versionMatches(vs, versions.minecraft_versions))) {
       matches = [...matches, v];
     }
     if (matches?.length == 0)
-      return toast.info("The latest version doesn't support " + vs);
+      return toast.info("The latest version doesn't support " + dpvDictAll[vs]);
     tick().then(() => {
       document.querySelector("#download-content")?.scrollIntoView();
     });
@@ -71,24 +69,22 @@
             <p class="dark:text-zinc-100">Select a Minecraft version:</p>
             <div class="grid-auto-fit-lg grid gap-3">
               {#each Object.keys(dpvDictAll).reverse() ?? [] as v}
-                {#if stitchedVersions.includes(v)}
-                  {@const mcVersions = data.project?.latest_version
-                    ? data.project.latest_version.minecraft_versions.split(",")
-                    : []}
+                {#if versionMatches(v, stitchedVersions)}
+                  {@const mcVersions = data.project?.latest_version?.minecraft_versions ?? ""}
                   <button
                     data-test-btn="{v}"
                     class="flex cursor-pointer items-center space-x-2 rounded-md bg-slate-300 p-3 transition-all hover:scale-102 dark:bg-zinc-700
-                  {mcVersions.includes(v)
+                  {versionMatches(v, mcVersions)
                       ? ' dark:text-zinc-100'
                       : ' text-red-500'}"
                     on:click="{() => pickVersions(v)}">
-                    {#if !mcVersions.includes(v)}
+                    {#if !versionMatches(v, mcVersions)}
                       <IconAlert />
                     {/if}
                     <div
                       class="flex flex-grow items-center space-x-2 font-bold">
                       <p>{dpvDictAll[v] ?? v}</p>
-                      {#if mcVersions.includes(v)}
+                      {#if versionMatches(v, mcVersions)}
                         <p class="font-thin italic">
                           {data.project.latest_version?.version_code}
                         </p>

--- a/src/routes/project/[project]/download/+page.svelte
+++ b/src/routes/project/[project]/download/+page.svelte
@@ -7,7 +7,6 @@
   import ProjectInfo from "$lib/components/project/ProjectInfo.svelte";
   import ProjectNav from "$lib/components/project/ProjectNav.svelte";
   import VersionDisplay from "$lib/components/project/VersionDisplay.svelte";
-  import { minecraftVersions } from "$lib/globals/consts";
   import type { Version } from "$lib/globals/schema";
   import { user } from "$lib/globals/stores";
   import IconBack from "~icons/tabler/ArrowBack.svelte";
@@ -16,6 +15,7 @@
   import IconFiles from "~icons/tabler/Files.svelte";
   import autoAnimate from "@formkit/auto-animate";
   import { tick } from "svelte";
+  import { dpvDictAll } from "$lib/globals/versions";
 
   export let data: PageData;
 
@@ -70,7 +70,7 @@
           {#if data.versions?.length != 0}
             <p class="dark:text-zinc-100">Select a Minecraft version:</p>
             <div class="grid-auto-fit-lg grid gap-3">
-              {#each minecraftVersions.reverse() ?? [] as v}
+              {#each Object.keys(dpvDictAll).reverse() ?? [] as v}
                 {#if stitchedVersions.includes(v)}
                   {@const mcVersions = data.project?.latest_version
                     ? data.project.latest_version.minecraft_versions.split(",")
@@ -87,7 +87,7 @@
                     {/if}
                     <div
                       class="flex flex-grow items-center space-x-2 font-bold">
-                      <p>{v}</p>
+                      <p>{dpvDictAll[v]}</p>
                       {#if mcVersions.includes(v)}
                         <p class="font-thin italic">
                           {data.project.latest_version?.version_code}

--- a/src/routes/project/[project]/download/+page.svelte
+++ b/src/routes/project/[project]/download/+page.svelte
@@ -87,7 +87,7 @@
                     {/if}
                     <div
                       class="flex flex-grow items-center space-x-2 font-bold">
-                      <p>{dpvDictAll[v]}</p>
+                      <p>{dpvDictAll[v] ?? v}</p>
                       {#if mcVersions.includes(v)}
                         <p class="font-thin italic">
                           {data.project.latest_version?.version_code}

--- a/src/routes/project/[project]/edit/+page.svelte
+++ b/src/routes/project/[project]/edit/+page.svelte
@@ -24,7 +24,7 @@
   import IconDelete from "~icons/tabler/Trash.svelte";
   import IconNoIcon from "~icons/tabler/Upload.svelte";
   import IconX from "~icons/tabler/X.svelte";
-  import { dpvDict, dpvDictSnapshot, getDataPackVersion } from "$lib/globals/versions";
+  import { dpvDict, dpvDictAll, getDataPackVersion } from "$lib/globals/versions";
 
   let publishModal: Modal;
   let draftModal: Modal;
@@ -556,7 +556,7 @@
                 <Select
                   emptyString="{'Select Supported Minecraft Versions'}"
                   multi="{true}"
-                  options="{Object.values(showSnapshot ? dpvDictSnapshot : dpvDict).reverse()}"
+                  options="{Object.values(showSnapshot ? dpvDictAll : dpvDict).reverse()}"
                   bind:selected="{supportedVersions}" />
                 <input
                   name="showSnapshot"

--- a/src/routes/project/[project]/edit/+page.svelte
+++ b/src/routes/project/[project]/edit/+page.svelte
@@ -8,7 +8,7 @@
   import Modal from "$lib/components/modals/Modal.svelte";
   import VersionDisplay from "$lib/components/project/VersionDisplay.svelte";
 
-  import { categories, minecraftVersions } from "$lib/globals/consts";
+  import { categories } from "$lib/globals/consts";
   import { fetchAuthed } from "$lib/globals/functions";
 
   import autoAnimate from "@formkit/auto-animate";
@@ -24,11 +24,13 @@
   import IconDelete from "~icons/tabler/Trash.svelte";
   import IconNoIcon from "~icons/tabler/Upload.svelte";
   import IconX from "~icons/tabler/X.svelte";
+  import { dpvDict, dpvDictSnapshot, getDataPackVersion } from "$lib/globals/versions";
 
   let publishModal: Modal;
   let draftModal: Modal;
   let deleteModal: Modal;
 
+  let showSnapshot: boolean = false;
   let supportedVersions: Readable<string> = readable();
   let zipFile: File;
   let activePage = "details";
@@ -204,8 +206,17 @@
     versionFormData.append("filename", zipFile.name);
     versionFormData.append(
       "minecraft_versions",
-      JSON.stringify($supportedVersions.split(",").map(s => s.trim()))
+      JSON.stringify(
+        [...new Set(
+          $supportedVersions
+            .split(",")
+            .map(s => s.trim())
+            .map(s => getDataPackVersion(s))
+        )]
+      )
     );
+
+    versionFormData.delete("showSnapshot");
 
     if (!vRPUsed) {
       versionFormData.delete("v_rp");
@@ -545,8 +556,19 @@
                 <Select
                   emptyString="{'Select Supported Minecraft Versions'}"
                   multi="{true}"
-                  options="{minecraftVersions}"
+                  options="{Object.values(showSnapshot ? dpvDictSnapshot : dpvDict).reverse()}"
                   bind:selected="{supportedVersions}" />
+                <input
+                  name="showSnapshot"
+                  id="showSnapshot"
+                  type="checkbox"
+                  bind:checked="{showSnapshot}"
+                  class=" h-10 align-middle" />
+                <label
+                  for="showSnapshot"
+                  class="align-middle text-zinc-950 dark:text-zinc-100">
+                  Show Snapshot Versions
+                </label>
                 <div class="mb-8"></div>
                 <input
                   name="squash"

--- a/src/routes/project/[project]/versions/+page.svelte
+++ b/src/routes/project/[project]/versions/+page.svelte
@@ -3,18 +3,19 @@
   import ProjectNav from "$lib/components/project/ProjectNav.svelte";
   import VersionDisplay from "$lib/components/project/VersionDisplay.svelte";
   import Select from "$lib/components/utility/Select.svelte";
-  import { minecraftVersions } from "$lib/globals/consts";
   import type { Version } from "$lib/globals/schema";
   import autoAnimate from "@formkit/auto-animate";
   import { readable } from "svelte/store";
   import IconBack from "~icons/tabler/ArrowBack.svelte";
   import type { PageData } from "./$types";
+  import { dpvDict, dpvDictAll } from "$lib/globals/versions";
 
   export let data: PageData;
 
   // Local vars
 
   let selectedVersions = readable("");
+  let showSnapshot = false;
 
   // Version filtering
   $: versionMatches =
@@ -23,7 +24,7 @@
       : data.versions.filter((dp: Version) =>
           dp.minecraft_versions
             .split(",")
-            .some(version => $selectedVersions.split(", ").includes(version))
+            .some(version => $selectedVersions.split(", ").includes(dpvDictAll[version]))
         );
 </script>
 
@@ -55,7 +56,18 @@
               emptyString="{'Filter by Minecraft Versions'}"
               multi="{true}"
               bind:selected="{selectedVersions}"
-              options="{minecraftVersions}" />
+              options="{Object.values(showSnapshot ? dpvDictAll : dpvDict).reverse()}" />
+            <input
+              name="showSnapshot"
+              id="showSnapshot"
+              type="checkbox"
+              bind:checked="{showSnapshot}"
+              class=" h-10 align-middle" />
+            <label
+              for="showSnapshot"
+              class="align-middle text-zinc-950 dark:text-zinc-100">
+              Show Snapshot Versions
+            </label>
           </div>
           <ul use:autoAnimate class="space-y-2">
             {#each versionMatches ?? [] as version}


### PR DESCRIPTION
It breaks already uploaded versions but not in a non functional way - just pack_format will always be 1 for them any some compatibility might be wrong but it should mostly work - special cases for 1.20.2 and 1.20.3/1.20.4 in that case 👍 

Can work without backend change, will just not sort "new" version format correctly