### PR TITLE
Update error page

### DIFF
--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -3,29 +3,39 @@
 
   let message = $page.error?.message;
   let description = $page.error?.description;
+  let STATUS = $page.status
+  // STATUS = 501; // DEBUG ONLY
 
   // if description not set, fallback to default message for status code
   if (!description) {
-    switch ($page.status) {
+    switch (STATUS) {
       case 401: {
+        message =
+          "Unauthorized"
         description =
           "Hey there datpack enthusiast! Have we met before? Sign in to your account to access this page.";
         break;
       }
 
       case 403: {
+        message =
+          "Forbidden"
         description =
           "Forbidden fruit! This page is tempting, but unfortunately, it's off-limits for now. Don't worry, we have plenty of other juicy datapacks for you to enjoy!";
         break;
       }
 
       case 404: {
+        message = 
+          "Not Found"
         description =
           "Looks like you hit a block in your adventure, but don't worry, we've got plenty of awesome projects to help you break through. Unfortunately, this page isn't one of them.";
         break;
       }
 
       case 500: {
+        message =
+          "Internal Server Error"
         description =
           "A creeper exploded in our server room, but our Redstone engineers are on the case fixing it, try again in a few minutes.";
         break;
@@ -48,24 +58,203 @@
   class="flex h-screen w-full flex-col items-center justify-center bg-slate-50 px-4 transition-colors dark:bg-zinc-900 sm:px-8 md:flex-row md:justify-start md:px-16 lg:px-24">
   
   <!-- HTTP response status code -->
-  <div class="w-full md:w-1/2">
+  <div class="w-full mx-10 md:w-1/2">
     <p
-      class="w-full text-center mb-8 font-console text-8xl font-bold text-zinc-950 dark:text-white md:mb-0 md:text-9xl lg:text-[10rem] xl:text-[12rem]">
-      {$page.status}
+      class="w-full text-center font-console text-8xl font-bold text-zinc-950 dark:text-white md:mb-0 md:text-9xl lg:text-[10rem] xl:text-[12rem]">
+      {STATUS}
     </p>
     <p
-      class="w-full text-center mb-6 font-console text-4xl font-bold text-zinc-950 dark:text-white md:text-5xl lg:text-6xl xl:text-7xl">
+      class="w-full text-center my-4 font-console text-4xl font-bold text-zinc-950 dark:text-white md:text-5xl lg:text-6xl xl:text-7xl">
       {message}
     </p>
   </div>
   
-  <!-- Details -->
-  <div class="w-full md:w-1/2">
-    <p
-        class="text-center text-lg text-zinc-950/40 dark:text-white/40 md:text-left md:text-xl lg:text-2xl">
+  <!-- details -->
+  <div class="w-full my-4 md:w-1/2">
+    <div
+      class="w-full rounded-lg bg-slate-200 p-4 dark:bg-zinc-800 lg:col-auto">
+      <p
+        class="mb-4 text-lg dark:text-zinc-100">
         {description}
-    </p>
-  </div>
+      </p>
 
-  
+      <!-- select buttons depending on status -->
+      <!-- Unauthorized -->
+      {#if STATUS == 401}
+      <div class="grid-auto-fit-2md grid gap-4">
+        <a
+          href="/login"
+          class="button-base flex items-center justify-center gap-3 bg-[#ff631a] text-white">
+          <img
+            src="/logos/dph.svg"
+            alt="dph logo"
+            class="h-4 self-center" />
+          Sign In
+        </a>
+      </div>
+
+      <!-- Forbidden -->
+      {:else if STATUS == 403}
+      <div class="grid-auto-fit-2md grid gap-4">
+        <a
+          href="/"
+          class="button-base flex items-center justify-center gap-3 bg-[#ff631a] text-white">
+          <img
+            src="/logos/dph.svg"
+            alt="dph logo"
+            class="h-4 self-center" />
+          Home
+        </a>
+        <a
+          href="/explore"
+          class="button-base flex items-center justify-center gap-3 bg-[#ff631a] text-white">
+          <img
+            src="/logos/dph.svg"
+            alt="dph logo"
+            class="h-4 self-center" />
+          Explore Projects
+        </a>
+      </div>
+      <p
+        class="my-4 text-lg dark:text-zinc-100">
+        Do you believe you should have access to this place? Report the issue!
+      </p>
+      <div class="grid-auto-fit-2md grid gap-4">
+        <a
+          href="https://discord.datapackhub.net"
+          class="button-base flex items-center justify-center gap-3 bg-[#5865F2] text-white">
+          <img
+            src="/logos/discord-white.svg"
+            alt="discord logo"
+            class="h-4 self-center" />
+          Discord
+        </a>
+        <a
+          href="https://github.com/Datapack-Hub/api"
+          class="button-base flex items-center justify-center gap-3 bg-black text-white">
+          <img
+            src="/logos/github-white.svg"
+            alt="github logo"
+            class="h-4 self-center" />
+          API Repo
+        </a>
+        <a
+          href="https://github.com/Datapack-Hub/frontend"
+          class="button-base flex items-center justify-center gap-3 bg-black text-white">
+          <img
+            src="/logos/github-white.svg"
+            alt="github logo"
+            class="h-4 self-center" />
+          Site Repo
+        </a>
+      </div>
+
+      <!-- Not Found -->
+      {:else if STATUS == 404}
+      <div class="grid-auto-fit-2md grid gap-4">
+        <a
+          href="/"
+          class="button-base flex items-center justify-center gap-3 bg-[#ff631a] text-white">
+          <img
+            src="/logos/dph.svg"
+            alt="dph logo"
+            class="h-4 self-center" />
+          Home
+        </a>
+        <a
+          href="/explore"
+          class="button-base flex items-center justify-center gap-3 bg-[#ff631a] text-white">
+          <img
+            src="/logos/dph.svg"
+            alt="dph logo"
+            class="h-4 self-center" />
+          Explore Projects
+        </a>
+      </div>
+      <p
+        class="my-4 text-lg dark:text-zinc-100">
+        Do you think something should be here? Report the issue!
+      </p>
+      <div class="grid-auto-fit-2md grid gap-4">
+        <a
+          href="https://discord.datapackhub.net"
+          class="button-base flex items-center justify-center gap-3 bg-[#5865F2] text-white">
+          <img
+            src="/logos/discord-white.svg"
+            alt="discord logo"
+            class="h-4 self-center" />
+          Discord
+        </a>
+        <a
+          href="https://github.com/Datapack-Hub/api"
+          class="button-base flex items-center justify-center gap-3 bg-black text-white">
+          <img
+            src="/logos/github-white.svg"
+            alt="github logo"
+            class="h-4 self-center" />
+          API Repo
+        </a>
+        <a
+          href="https://github.com/Datapack-Hub/frontend"
+          class="button-base flex items-center justify-center gap-3 bg-black text-white">
+          <img
+            src="/logos/github-white.svg"
+            alt="github logo"
+            class="h-4 self-center" />
+          Site Repo
+        </a>
+      </div>
+
+      <!-- Internal Server Error -->
+      {:else if STATUS == 500}
+        <p
+          class="mb-4 text-lg dark:text-zinc-100">
+          You can check our discord server for updates, if you want.
+        </p>
+        <div class="grid-auto-fit-2md grid gap-4">
+          <a
+            href="https://discord.datapackhub.net"
+            class="button-base flex items-center justify-center gap-3 bg-[#5865F2] text-white">
+            <img
+              src="/logos/discord-white.svg"
+              alt="discord logo"
+              class="h-4 self-center" />
+            Discord
+          </a>
+        </div>
+
+      <!-- default -->
+      {:else}
+        <div class="grid-auto-fit-2md grid gap-4">
+          <a
+            href="https://discord.datapackhub.net"
+            class="button-base flex items-center justify-center gap-3 bg-[#5865F2] text-white">
+            <img
+              src="/logos/discord-white.svg"
+              alt="discord logo"
+              class="h-4 self-center" />
+            Discord
+          </a>
+          <a
+            href="https://github.com/Datapack-Hub/api"
+            class="button-base flex items-center justify-center gap-3 bg-black text-white">
+            <img
+              src="/logos/github-white.svg"
+              alt="github logo"
+              class="h-4 self-center" />
+            API Repo
+          </a>
+          <a
+            href="https://github.com/Datapack-Hub/frontend"
+            class="button-base flex items-center justify-center gap-3 bg-black text-white">
+            <img
+              src="/logos/github-white.svg"
+              alt="github logo"
+              class="h-4 self-center" />
+            Site Repo
+          </a>
+        </div>
+      {/if}
+    </div>
+  </div>
 </main>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,61 +1,71 @@
 <script lang="ts">
   import { page } from "$app/stores";
 
-  let message = $page.error?.description;
+  let message = $page.error?.message;
+  let description = $page.error?.description;
 
-  if (!message) {
+  // if description not set, fallback to default message for status code
+  if (!description) {
     switch ($page.status) {
-      case 404: {
-        message =
-          "Looks like you hit a block in your adventure, but don't worry, we've got plenty of datapacks to help you break through. Unfortunately, this page isn't one of them";
-        break;
-      }
-
       case 401: {
-        message =
-          "You are logged out, please log back in to enjoy all the luxuries we supply";
+        description =
+          "Hey there datpack enthusiast! Have we met before? Sign in to your account to access this page.";
         break;
       }
 
       case 403: {
-        message =
+        description =
           "Forbidden fruit! This page is tempting, but unfortunately, it's off-limits for now. Don't worry, we have plenty of other juicy datapacks for you to enjoy!";
         break;
       }
 
+      case 404: {
+        description =
+          "Looks like you hit a block in your adventure, but don't worry, we've got plenty of awesome projects to help you break through. Unfortunately, this page isn't one of them.";
+        break;
+      }
+
       case 500: {
-        message =
+        description =
           "A creeper exploded in our server room, but our Redstone engineers are on the case fixing it, try again in a few minutes.";
         break;
       }
 
       default: {
-        message =
-          "We haven't coded a message for this error yet! If you think we should, reach out to us, or, if you're a dev, make a pull request.";
+        description =
+          "Our spyglasses haven't spotted this error yet! If you think we should know about it, reach out to us, or, if you're a dev, make a pull request.";
       }
     }
   }
 </script>
 
 <svelte:head>
-  <title>{$page.error?.message} | Datapack Hub</title>
+  <title>{message} | Datapack Hub</title>
 </svelte:head>
 
 <main
   id="main-content"
   class="flex h-screen w-full flex-col items-center justify-center bg-slate-50 px-4 transition-colors dark:bg-zinc-900 sm:px-8 md:flex-row md:justify-start md:px-16 lg:px-24">
-  <p
-    class="mb-8 w-full text-center font-console text-8xl font-bold text-zinc-950 dark:text-white md:mb-0 md:w-1/2 md:text-9xl lg:text-[10rem] xl:text-[12rem]">
-    {$page.status}
-  </p>
+  
+  <!-- HTTP response status code -->
   <div class="w-full md:w-1/2">
     <p
-      class="mb-6 text-center font-console text-4xl font-bold text-zinc-950 dark:text-white md:text-left md:text-5xl lg:text-6xl xl:text-7xl">
-      {$page.error?.message}
+      class="w-full text-center mb-8 font-console text-8xl font-bold text-zinc-950 dark:text-white md:mb-0 md:text-9xl lg:text-[10rem] xl:text-[12rem]">
+      {$page.status}
     </p>
     <p
-      class="text-center text-lg text-zinc-950/40 dark:text-white/40 md:text-left md:text-xl lg:text-2xl">
+      class="w-full text-center mb-6 font-console text-4xl font-bold text-zinc-950 dark:text-white md:text-5xl lg:text-6xl xl:text-7xl">
       {message}
     </p>
   </div>
+  
+  <!-- Details -->
+  <div class="w-full md:w-1/2">
+    <p
+        class="text-center text-lg text-zinc-950/40 dark:text-white/40 md:text-left md:text-xl lg:text-2xl">
+        {description}
+    </p>
+  </div>
+
+  
 </main>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -118,7 +118,7 @@
   <title>Datapack Hub</title>
   <meta
     name="description"
-    content="Datapack Hub is a website to find and download Minecraft datapacks. Join our datapacking discord" />
+    content="Datapack Hub is a website to find and download Minecraft datapacks. Join our datapacking discord." />
 </svelte:head>
 
 <svelte:window bind:scrollY />

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
   import CasualLine from "$lib/components/decorative/CasualLine.svelte";
-  import IconGithub from "~icons/tabler/BrandGithub.svelte";
-  import IconDiscord from "~icons/tabler/BrandDiscord.svelte";
   import { authed, user } from "$lib/globals/stores";
 </script>
 
@@ -38,13 +36,19 @@
         <a
           class="flex items-center space-x-2 rounded-lg bg-black p-3 font-bold text-white"
           href="https://api.datapackhub.net/auth/login/github">
-          <IconGithub />
+          <img
+            src="/logos/github-white.svg"
+            alt="github logo"
+            class="h-4 self-center" />
           <p>Sign In with Github</p>
         </a>
         <a
           class="flex items-center space-x-2 rounded-lg bg-[#5865F2] p-3 font-bold text-white"
           href="https://api.datapackhub.net/auth/login/discord">
-          <IconDiscord />
+          <img
+            src="/logos/discord-white.svg"
+            alt="discord logo"
+            class="h-4 self-center" />
           <p>Sign In with Discord</p>
         </a>
       </div>

--- a/src/routes/moderation/+page.server.ts
+++ b/src/routes/moderation/+page.server.ts
@@ -17,7 +17,8 @@ export const load = (async ({ cookies, fetch }) => {
       async (response: Response) => {
         if (response.ok) return await response.json();
         error(response.status, {
-          message: response.statusText
+          message: response.statusText,
+          description: undefined
         });
       }
     );

--- a/src/routes/notifications/+page.server.ts
+++ b/src/routes/notifications/+page.server.ts
@@ -9,7 +9,7 @@ export const load = (async ({ cookies, fetch }) => {
   if (!unread.ok) {
     error(unread.status, {
       message: unread.statusText,
-      description: "Something went wrong"
+      description: undefined
     });
   }
 

--- a/src/routes/project/[project]/+page.server.ts
+++ b/src/routes/project/[project]/+page.server.ts
@@ -14,15 +14,15 @@ export const load = (async ({ params, fetch, cookies, url }) => {
 
   if ([projectRequest.status, versionsRequest.status].includes(404)) {
     error(404, {
-      message: "Project not found",
-      description: "Why not go ahead and turn the idea into a reality?"
+      message: "Project Not Found",
+      description: "Sadly, we couldn't find the project you're looking for. Why don't you go ahead and turn the idea into a reality?"
     });
   }
 
   if ([projectRequest, versionsRequest].some(request => !request.ok)) {
     error(projectRequest.status, {
-      message: "Unexpected error",
-      description: "Something unexpected happen, try again later"
+      message: projectRequest.statusText,
+      description: undefined
     });
   }
 

--- a/src/routes/project/[project]/+page.server.ts
+++ b/src/routes/project/[project]/+page.server.ts
@@ -14,8 +14,8 @@ export const load = (async ({ params, fetch, cookies, url }) => {
 
   if ([projectRequest.status, versionsRequest.status].includes(404)) {
     error(404, {
-      message: "Project Not Found",
-      description: "Sadly, we couldn't find the project you're looking for. Why don't you go ahead and turn the idea into a reality?"
+      message: projectRequest.statusText,
+      description: "We've searched thoroughly, but found nothing except a few cobwebs. No project around here. Why don't you go ahead and turn the idea into a reality yourself?"
     });
   }
 

--- a/src/routes/project/[project]/comments/+page.server.ts
+++ b/src/routes/project/[project]/comments/+page.server.ts
@@ -16,15 +16,15 @@ export const load = (async ({ params, fetch, cookies, url }) => {
 
   if (projectRequest.status === 404) {
     error(404, {
-      message: "Project not found",
-      description: "Why not go ahead and turn the idea into a reality?"
+      message: "Project Not Found",
+      description: "Welp, this is kinda awkward. You probably wanted to leave a quality comment, but sadly we couldn't find this project."
     });
   }
 
   if (!projectRequest.ok) {
     error(projectRequest.status, {
-      message: "Unexpected error",
-      description: "Something unexpected happen, try again later"
+      message: projectRequest.statusText,
+      description: undefined
     });
   }
 

--- a/src/routes/project/[project]/comments/+page.server.ts
+++ b/src/routes/project/[project]/comments/+page.server.ts
@@ -16,7 +16,7 @@ export const load = (async ({ params, fetch, cookies, url }) => {
 
   if (projectRequest.status === 404) {
     error(404, {
-      message: "Project Not Found",
+      message: projectRequest.status,
       description: "Welp, this is kinda awkward. You probably wanted to leave a quality comment, but sadly we couldn't find this project."
     });
   }

--- a/src/routes/project/[project]/download/+page.server.ts
+++ b/src/routes/project/[project]/download/+page.server.ts
@@ -14,15 +14,15 @@ export const load = (async ({ params, fetch, cookies, url }) => {
 
   if ([projectRequest.status, versionsRequest.status].includes(404)) {
     error(404, {
-      message: "Project not found",
-      description: "Why not go ahead and turn the idea into a reality?"
+      message: "Project Not Found",
+      description: "We've searched thoroughly, but found nothing except a few cobwebs. No files to download around here."
     });
   }
 
   if ([projectRequest, versionsRequest].some(request => !request.ok)) {
     error(projectRequest.status, {
-      message: "Unexpected error",
-      description: "Something unexpected happen, try again later"
+      message: projectRequest.statusText,
+      description: undefined
     });
   }
 

--- a/src/routes/project/[project]/download/+page.server.ts
+++ b/src/routes/project/[project]/download/+page.server.ts
@@ -14,8 +14,8 @@ export const load = (async ({ params, fetch, cookies, url }) => {
 
   if ([projectRequest.status, versionsRequest.status].includes(404)) {
     error(404, {
-      message: "Project Not Found",
-      description: "We've searched thoroughly, but found nothing except a few cobwebs. No files to download around here."
+      message: projectRequest.statusText,
+      description: "This chest seems to be empty. No files to download in here..."
     });
   }
 

--- a/src/routes/project/[project]/edit/+page.server.ts
+++ b/src/routes/project/[project]/edit/+page.server.ts
@@ -37,7 +37,7 @@ export const load = (async event => {
 
   if (projectRequest.status === 404) {
     error(404, {
-      message: "Project Not Found",
+      message: projectRequest.statusText,
       description: "How you tried creating a project before editing it? I heard that's a much better way of doin' things."
     });
   }
@@ -51,7 +51,7 @@ export const load = (async event => {
 
   if (meRequest.status === 401) {
     error(401, {
-      message: "Unauthorized",
+      message: meRequest.statusText,
       description: undefined
     });
   }

--- a/src/routes/project/[project]/edit/+page.server.ts
+++ b/src/routes/project/[project]/edit/+page.server.ts
@@ -37,8 +37,8 @@ export const load = (async event => {
 
   if (projectRequest.status === 404) {
     error(404, {
-      message: "Silly boy!",
-      description: "Doesn't exist, nerd!"
+      message: "Project Not Found",
+      description: "How you tried creating a project before editing it? I heard that's a much better way of doin' things."
     });
   }
 
@@ -51,8 +51,8 @@ export const load = (async event => {
 
   if (meRequest.status === 401) {
     error(401, {
-      message: "Please sign in.",
-      description: "If you are signed in, then our server must be down. Sorry!"
+      message: "Unauthorized",
+      description: undefined
     });
   }
 
@@ -79,8 +79,8 @@ export const load = (async event => {
   }
 
   error(403, {
-    message: "Not your project.",
-    description: "Only the owner can edit this."
+    message: "Forbidden",
+    description: "Hello there, little prankster. Only the owner can edit this project."
   });
 }) satisfies PageServerLoad;
 

--- a/src/routes/project/[project]/versions/+page.server.ts
+++ b/src/routes/project/[project]/versions/+page.server.ts
@@ -14,7 +14,7 @@ export const load = (async ({ params, fetch, cookies, url }) => {
 
   if ([projectRequest.status, versionsRequest.status].includes(404)) {
     error(404, {
-      message: "Project Not Found",
+      message: projectRequest.statusText,
       description: undefined
     });
   }

--- a/src/routes/project/[project]/versions/+page.server.ts
+++ b/src/routes/project/[project]/versions/+page.server.ts
@@ -14,15 +14,15 @@ export const load = (async ({ params, fetch, cookies, url }) => {
 
   if ([projectRequest.status, versionsRequest.status].includes(404)) {
     error(404, {
-      message: "Project not found",
-      description: "Why not go ahead and turn the idea into a reality?"
+      message: "Project Not Found",
+      description: undefined
     });
   }
 
   if ([projectRequest, versionsRequest].some(request => !request.ok)) {
     error(projectRequest.status, {
-      message: "Unexpected error",
-      description: "Something unexpected happen, try again later"
+      message: projectRequest.statusText,
+      description: undefined
     });
   }
 

--- a/src/routes/user/[user]/+page.ts
+++ b/src/routes/user/[user]/+page.ts
@@ -17,15 +17,15 @@ export const load = (async ({ params, fetch }) => {
 
   if (user.status === 404) {
     error(404, {
-      message: "User not found",
-      description: "You may have hallucinated their existence"
+      message: "User Not Found",
+      description: "We couldn't find that entity. You may have hallucinated their existence"
     });
   }
 
   if ([user, projects].some(r => !r.ok)) {
     error(user.status, {
-      message: "Unexpected error",
-      description: "Something unexpected happen, try again later"
+      message: user.statusText,
+      description: undefined
     });
   }
 

--- a/src/routes/user/[user]/+page.ts
+++ b/src/routes/user/[user]/+page.ts
@@ -17,7 +17,7 @@ export const load = (async ({ params, fetch }) => {
 
   if (user.status === 404) {
     error(404, {
-      message: "User Not Found",
+      message: user.statusText,
       description: "We couldn't find that entity. You may have hallucinated their existence"
     });
   }

--- a/src/routes/user/[user]/edit/+page.ts
+++ b/src/routes/user/[user]/edit/+page.ts
@@ -28,8 +28,8 @@ export const load = (async ({ params, fetch }) => {
         !defaultRole.permissions.includes("EDIT_USER")
       ) {
         error(403, {
-          message: "Not allowed!",
-          description: "This is not you, you can't edit their profile."
+          message: "Forbidden",
+          description: "Hello there, little prankster. This is not you, you can't edit their profile."
         });
       }
 


### PR DESCRIPTION
I tried to improve the error page by updating various error messages and providing helpful links in some cases. For example, the Error 401 (Unauthorized) provides a button to sign in and 403 (Forbidden) links to `/` and `/explore`, as well as to discord/github in case the user wants to report the error as a bug.

Desktop:
![401](https://github.com/Datapack-Hub/frontend/assets/114934849/0b25c12e-5d98-42b3-963e-94185ae3e05b)
![403](https://github.com/Datapack-Hub/frontend/assets/114934849/f7124a9d-5d9c-4300-b526-430b8d9cd11e)
![404](https://github.com/Datapack-Hub/frontend/assets/114934849/3d616391-ce2c-4c32-9494-f751783d55fd)
![500](https://github.com/Datapack-Hub/frontend/assets/114934849/94179895-0efd-42ce-b087-7c6063d8b79c)
![default](https://github.com/Datapack-Hub/frontend/assets/114934849/61750c09-6b98-4659-a587-6e45abc57b59)

Mobile:
![mobile](https://github.com/Datapack-Hub/frontend/assets/114934849/a5e65f01-197f-466f-8e13-621c3ac3d685)


closes #16 