### PR TITLE
fix thumbnail size

### DIFF
--- a/src/lib/components/project/ProjectCard.svelte
+++ b/src/lib/components/project/ProjectCard.svelte
@@ -33,7 +33,7 @@
       href="/project/{project.url}"
       class="rounded-lg {project.icon
         ? ''
-        : 'bg-slate-300 p-4 dark:bg-zinc-700 dark:text-zinc-100'} items-start pt-2">
+        : 'bg-slate-300 p-4 w-20 h-20 dark:bg-zinc-700 dark:text-zinc-100'} items-start">
       {#if project.icon}
         <img
           src="{project.icon}"
@@ -42,7 +42,7 @@
           height="80"
           class="aspect-square w-20 rounded-lg bg-cover" />
       {:else}
-        <IconNoPhoto width="48" height="48" />
+        <IconNoPhoto width="48" height="48"/>
       {/if}
     </a>
     <div class="ml-4 w-3/4">


### PR DESCRIPTION
If the user doesn't upload a thumbnail, the image would previously stretch to the height of the project info, while all other thumbnails are square:

OLD:
![old](https://github.com/Datapack-Hub/frontend/assets/114934849/e14f9601-5ffc-4afe-8361-5ca13c76b2ab)

NEW:
![new](https://github.com/Datapack-Hub/frontend/assets/114934849/6bc4a01f-f24c-44e2-bce9-25a66a870d3d)
