### PR TITLE
fix header/content overlap on homepage

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -128,7 +128,7 @@
   class="h-full bg-slate-50 transition-all dark:bg-zinc-900">
   <div class="py-12 md:py-0"></div>
   <section
-    class="thing flex h-fit w-full flex-col items-center justify-start overflow-visible px-4 md:h-[85vh] md:flex-row md:justify-evenly lg:px-8">
+    class="thing flex h-fit w-full flex-col items-center justify-start overflow-visible px-4 md:pt-10 md:pb-5 md:flex-row md:justify-evenly lg:px-8">
     <div class="w-full md:w-5/12">
       <div class="relative h-36 w-full">
         <h1


### PR DESCRIPTION
If the screen height was not big enough, the header and content of the homepage could overlap. This leads to some content being overlapped by the header, even if you scroll to the very top of the page. In this example, I scrolled to the very top with a slightly lower screen height and the "Featured Projects" caption is still half-way under the header.

OLD:
![old](https://github.com/Datapack-Hub/frontend/assets/114934849/3c5c55ef-c9d6-4cbf-86a7-60bd4dceff94)

NEW:
![new](https://github.com/Datapack-Hub/frontend/assets/114934849/d69beafc-ce94-4772-8a5e-b6cd0037736e)