### PR TITLE
update slug error messages

### DIFF
--- a/src/routes/projects/new/+page.server.ts
+++ b/src/routes/projects/new/+page.server.ts
@@ -8,9 +8,13 @@ const newProjectSchema = z.object({
   icon: z.ostring(),
   url: z
     .string()
-    .regex(/^[1-9a-z]+(-[1-9a-z]+)*$/, {
-      message: "Slug can only contain alphanumeric characters and hyphens!"
+    .regex(/^-*[1-9a-z]+(-[1-9a-z]+)*$/, {
+      message: "Slug can only contain lower case alphanumeric characters and hyphens!"
     })
+    .regex(/^-/, {
+      message: "Slug may not start with a hyphen!"
+    })
+    .min(1, { message: "Slug is empty!" })
     .max(35, { message: "Slug too long!" }),
   title: z.string().max(35, { message: "Title too long!" }),
   description: z.string().min(3).max(200, { message: "Summary too long!" }),


### PR DESCRIPTION
Slugs now show a different error message if the slug is empty, or starts with a hyphen.